### PR TITLE
Load resources over https

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,10 +10,10 @@
 
     <title>PLUTO Data Downloader powered by Carto</title>
 
-    <link href='http://fonts.googleapis.com/css?family=Lato:300,400,700' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Lato:300,400,700' rel='stylesheet' type='text/css'>
 
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="//libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
     <link rel="stylesheet" href="css/vendor/leaflet.draw.css">
     <link rel="stylesheet" href="css/styleguide.min.css">
     <link rel="stylesheet" type="text/css" href="css/icons.css">


### PR DESCRIPTION
Currently, https://chriswhong.github.io/plutoplus/ does not load all resources because some were hardcoded to use `http`. ;) 